### PR TITLE
Clear input after adding post/comment (refs #3)

### DIFF
--- a/client/app/Dashboard/components/AddComment.jsx
+++ b/client/app/Dashboard/components/AddComment.jsx
@@ -32,6 +32,7 @@ export class AddComment extends React.Component {
     let csrfToken = ReactOnRails.authenticityToken()
     event.preventDefault()
     this.props.addComment(this.props.postId, this.state.commentText, csrfToken)
+    event.target.reset();
   }
 
   render() {
@@ -41,11 +42,11 @@ export class AddComment extends React.Component {
           <div className='form-group'>
             <input
               className='form-control'
+              defaultValue=''
               name='commentText'
               onChange={this.inputValueChange}
               placeholder='Comment it!'
               ref='commentTextInput'
-              value={this.state.commentText}
             />
           </div>
           <input

--- a/client/app/Dashboard/components/AddPost.jsx
+++ b/client/app/Dashboard/components/AddPost.jsx
@@ -35,6 +35,7 @@ export class AddPost extends React.Component {
     let csrfToken = ReactOnRails.authenticityToken()
     event.preventDefault()
     this.props.addPost(this.state.postText, csrfToken)
+    event.target.reset();
   }
 
   render() {
@@ -43,11 +44,11 @@ export class AddPost extends React.Component {
         <form className='form-inline' onSubmit={this.createPost}>
           <textarea
             className='form-control'
+            defaultValue=''
             name='postText'
             onChange={this.inputValueChange}
             placeholder="What's going on?"
             ref='postTextInput'
-            value={this.state.postText}
           />
           <input
             className='btn btn-primary'


### PR DESCRIPTION
I removed `value={this.state.[fieldhere]}` because state is already being changed via `inputValueChange` handler, and added empty `defaultValue` instead - this fixed call for `event.target.reset()` because inputs reset to input `value` vield (and states were changing these).